### PR TITLE
Feature consistent http headers

### DIFF
--- a/lib/mumukit/bridge/runner.rb
+++ b/lib/mumukit/bridge/runner.rb
@@ -88,6 +88,8 @@ module Mumukit
         JSON.parse raw_get_to_server(:info, options.merge(content_type: :json))
       end
 
+      private
+
       def with_server_response(request, route, &action)
         response = post_to_server(request, route)
         action.call(response)
@@ -108,8 +110,6 @@ module Mumukit
                        open_timeout: @timeout,
                        headers: {content_type: :json}).execute()
       end
-
-      private
 
       def get_assets_for(kind, content_type)
         absolutize(@language_json.dig("#{kind}_assets_urls", content_type) || [])

--- a/lib/mumukit/bridge/runner.rb
+++ b/lib/mumukit/bridge/runner.rb
@@ -6,11 +6,12 @@ require_relative './runner/boolean'
 module Mumukit
   module Bridge
     class Runner
-      attr_accessor :test_runner_url
+      attr_accessor :test_runner_url, :timeout, :headers
 
-      def initialize(test_runner_url, timeout=10)
+      def initialize(test_runner_url, timeout=10, headers={})
         @test_runner_url = test_runner_url
         @timeout = timeout
+        @headers = headers
       end
 
       # Expects a hash

--- a/lib/mumukit/bridge/runner.rb
+++ b/lib/mumukit/bridge/runner.rb
@@ -81,27 +81,27 @@ module Mumukit
       end
 
       def assets(path, options={})
-        raw_get_to_server "assets/#{path}", options
+        do_get "assets/#{path}", options
       end
 
       def info(options={})
-        JSON.parse raw_get_to_server(:info, options.merge(content_type: :json))
+        JSON.parse do_get(:info, options.merge(content_type: :json))
       end
 
       private
 
       def with_server_response(request, route, &action)
-        response = post_to_server(request, route)
+        response = do_post(request, route)
         action.call(response)
       rescue Exception => e
         {result: e.message, status: :aborted}
       end
 
-      def raw_get_to_server(route, options)
+      def do_get(route, options)
         RestClient.get("#{test_runner_url}/#{route}", options)
       end
 
-      def post_to_server(request, route)
+      def do_post(request, route)
         JSON.parse RestClient::Request.new(
                        method: :post,
                        url: "#{test_runner_url}/#{route}",

--- a/lib/mumukit/bridge/runner.rb
+++ b/lib/mumukit/bridge/runner.rb
@@ -85,7 +85,7 @@ module Mumukit
       end
 
       def info(headers={})
-        JSON.parse do_get(:info, headers.merge(content_type: :json))
+        JSON.parse do_get(:info, json_content_type(headers))
       end
 
       private
@@ -98,7 +98,7 @@ module Mumukit
       end
 
       def do_get(route, headers)
-        RestClient.get("#{test_runner_url}/#{route}", headers)
+        RestClient.get "#{test_runner_url}/#{route}", build_headers(headers)
       end
 
       def do_post(route, request, headers)
@@ -108,7 +108,7 @@ module Mumukit
                        payload: request.to_json,
                        timeout: @timeout,
                        open_timeout: @timeout,
-                       headers: headers.merge(content_type: :json)).execute
+                       headers: build_headers(json_content_type(headers))).execute
       end
 
       def get_assets_for(kind, content_type)
@@ -117,6 +117,14 @@ module Mumukit
 
       def absolutize(urls)
         urls.map { |url| "#{test_runner_url}/#{url}"}
+      end
+
+      def build_headers(headers)
+        self.headers.merge(headers)
+      end
+
+      def json_content_type(headers)
+        headers.merge(content_type: :json)
       end
     end
   end

--- a/lib/mumukit/bridge/runner.rb
+++ b/lib/mumukit/bridge/runner.rb
@@ -91,7 +91,7 @@ module Mumukit
       private
 
       def with_server_response(request, route, &action)
-        response = do_post(request, route)
+        response = do_post(route, request)
         action.call(response)
       rescue Exception => e
         {result: e.message, status: :aborted}
@@ -101,7 +101,7 @@ module Mumukit
         RestClient.get("#{test_runner_url}/#{route}", options)
       end
 
-      def do_post(request, route)
+      def do_post(route, request)
         JSON.parse RestClient::Request.new(
                        method: :post,
                        url: "#{test_runner_url}/#{route}",

--- a/lib/mumukit/bridge/runner.rb
+++ b/lib/mumukit/bridge/runner.rb
@@ -23,7 +23,7 @@ module Mumukit
       #    expectation_results: [{binding:string, inspection:string, result:symbol}],
       #    feedback: string}
       def run_tests!(request, headers={})
-        with_server_response request, 'test', headers do |response|
+        with_server_response 'test', request, headers do |response|
           response_type = ResponseType.for_response response
           response_type.parse response
         end
@@ -35,13 +35,13 @@ module Mumukit
       #   {result: string,
       #    status: :passed|:failed|:errored|:aborted}
       def run_query!(request, headers={})
-        with_server_response request, 'query', headers do |it|
+        with_server_response 'query', request, headers do |it|
           {status: it['exit'].to_sym, result: it['out']}
         end
       end
 
       def run_try!(request, headers={})
-        with_server_response request, 'try', headers do |it|
+        with_server_response 'try', request, headers do |it|
           {
             status: it['exit'].to_sym,
             result: it['out'],
@@ -90,7 +90,7 @@ module Mumukit
 
       private
 
-      def with_server_response(request, route, headers, &action)
+      def with_server_response(route, request, headers, &action)
         response = do_json_post(route, request, headers)
         action.call(response)
       rescue RestClient::ExceptionWithResponse => e

--- a/lib/mumukit/bridge/runner.rb
+++ b/lib/mumukit/bridge/runner.rb
@@ -22,8 +22,8 @@ module Mumukit
       #    status: :passed|:failed|:errored|:aborted|:passed_with_warnings,
       #    expectation_results: [{binding:string, inspection:string, result:symbol}],
       #    feedback: string}
-      def run_tests!(request)
-        with_server_response request, 'test' do |response|
+      def run_tests!(request, headers={})
+        with_server_response request, 'test', headers do |response|
           response_type = ResponseType.for_response response
           response_type.parse response
         end
@@ -34,14 +34,14 @@ module Mumukit
       # Returns a hash
       #   {result: string,
       #    status: :passed|:failed|:errored|:aborted}
-      def run_query!(request)
-        with_server_response request, 'query' do |it|
+      def run_query!(request, headers={})
+        with_server_response request, 'query', headers do |it|
           {status: it['exit'].to_sym, result: it['out']}
         end
       end
 
-      def run_try!(request)
-        with_server_response request, 'try' do |it|
+      def run_try!(request, headers={})
+        with_server_response request, 'try', headers do |it|
           {
             status: it['exit'].to_sym,
             result: it['out'],
@@ -53,8 +53,8 @@ module Mumukit
         end
       end
 
-      def importable_info
-        @language_json ||= info.merge('url' => test_runner_url)
+      def importable_info(headers={})
+        @language_json ||= info(headers).merge('url' => test_runner_url)
         {
           name:                   @language_json['name'],
           comment_type:           @language_json['comment_type'],
@@ -80,35 +80,35 @@ module Mumukit
         }
       end
 
-      def assets(path, options={})
-        do_get "assets/#{path}", options
+      def assets(path, headers={})
+        do_get "assets/#{path}", headers
       end
 
-      def info(options={})
-        JSON.parse do_get(:info, options.merge(content_type: :json))
+      def info(headers={})
+        JSON.parse do_get(:info, headers.merge(content_type: :json))
       end
 
       private
 
-      def with_server_response(request, route, &action)
-        response = do_post(route, request)
+      def with_server_response(request, route, headers, &action)
+        response = do_post(route, request, headers)
         action.call(response)
       rescue Exception => e
         {result: e.message, status: :aborted}
       end
 
-      def do_get(route, options)
-        RestClient.get("#{test_runner_url}/#{route}", options)
+      def do_get(route, headers)
+        RestClient.get("#{test_runner_url}/#{route}", headers)
       end
 
-      def do_post(route, request)
+      def do_post(route, request, headers)
         JSON.parse RestClient::Request.new(
                        method: :post,
                        url: "#{test_runner_url}/#{route}",
                        payload: request.to_json,
                        timeout: @timeout,
                        open_timeout: @timeout,
-                       headers: {content_type: :json}).execute()
+                       headers: headers.merge(content_type: :json)).execute
       end
 
       def get_assets_for(kind, content_type)

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -7,7 +7,7 @@ describe Mumukit::Bridge::Runner do
     let(:request) { {} }
     let(:response) { bridge.run_query!(request) }
 
-    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:post_to_server).and_return(server_response) }
+    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:do_post).and_return(server_response) }
 
     context 'when submission passed' do
       let(:server_response) { {

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -7,7 +7,7 @@ describe Mumukit::Bridge::Runner do
     let(:request) { {} }
     let(:response) { bridge.run_query!(request) }
 
-    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:do_post).and_return(server_response) }
+    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:do_json_post).and_return(server_response) }
 
     context 'when submission passed' do
       let(:server_response) { {

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Mumukit::Bridge::Runner do
+  describe 'headers' do
+    let(:bridge) { Mumukit::Bridge::Runner.new('http://foo', 10, foo: 'bar') }
+
+    it { expect(bridge.headers).to eq foo: 'bar' }
+  end
+end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -7,7 +7,7 @@ describe Mumukit::Bridge::Runner do
     let(:request) { {} }
     let(:response) { bridge.run_tests!(request) }
 
-    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:post_to_server).and_return(server_response) }
+    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:do_post).and_return(server_response) }
 
     context 'structured data' do
       context 'when submission passed' do

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -7,7 +7,7 @@ describe Mumukit::Bridge::Runner do
     let(:request) { {} }
     let(:response) { bridge.run_tests!(request) }
 
-    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:do_post).and_return(server_response) }
+    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:do_json_post).and_return(server_response) }
 
     context 'structured data' do
       context 'when submission passed' do

--- a/spec/try_spec.rb
+++ b/spec/try_spec.rb
@@ -8,7 +8,7 @@ describe Mumukit::Bridge::Runner do
     let(:request) { {} }
     let(:response) { bridge.run_try!(request) }
 
-    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:post_to_server).and_return(server_response) }
+    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:do_post).and_return(server_response) }
 
     context 'when goal achived' do
       let(:server_response) { {

--- a/spec/try_spec.rb
+++ b/spec/try_spec.rb
@@ -8,7 +8,7 @@ describe Mumukit::Bridge::Runner do
     let(:request) { {} }
     let(:response) { bridge.run_try!(request) }
 
-    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:do_post).and_return(server_response) }
+    before { expect_any_instance_of(Mumukit::Bridge::Runner).to receive(:do_json_post).and_return(server_response) }
 
     context 'when goal achived' do
       let(:server_response) { {


### PR DESCRIPTION
Modified runners bridge so that: 

* has better error messages for test/query/try hooks
* all methods accepts custom headers
* the runner object itself accepts custom headers 
* private were improved in order to be more consistent