### PR TITLE
adding shows_loading_content fields

### DIFF
--- a/lib/mumukit/bridge/runner.rb
+++ b/lib/mumukit/bridge/runner.rb
@@ -56,28 +56,30 @@ module Mumukit
       def importable_info(headers={})
         @language_json ||= info(headers).merge('url' => test_runner_url)
         {
-          name:                   @language_json['name'],
-          comment_type:           @language_json['comment_type'],
-          test_runner_url:        @language_json['url'],
-          output_content_type:    @language_json['output_content_type'],
-          prompt:                (@language_json.dig('language', 'prompt') || 'ム') + ' ',
-          extension:              @language_json.dig('language', 'extension'),
-          highlight_mode:         @language_json.dig('language', 'ace_mode'),
-          visible_success_output: @language_json.dig('language', 'graphic').present?,
-          devicon:                @language_json.dig('language', 'icon', 'name'),
-          triable:                @language_json.dig('features', 'try').present?,
-          feedback:               @language_json.dig('features', 'feedback').present?,
-          queriable:              @language_json.dig('features', 'query').present?,
-          stateful_console:       @language_json.dig('features', 'stateful').present?,
-          multifile:              @language_json.dig('features', 'multifile').present?,
-          test_extension:         @language_json.dig('test_framework', 'test_extension'),
-          test_template:          @language_json.dig('test_framework', 'template'),
-          layout_js_urls:         get_assets_for(:layout, 'js'),
-          layout_html_urls:       get_assets_for(:layout, 'html'),
-          layout_css_urls:        get_assets_for(:layout, 'css'),
-          editor_js_urls:         get_assets_for(:editor, 'js'),
-          editor_html_urls:       get_assets_for(:editor, 'html'),
-          editor_css_urls:        get_assets_for(:editor, 'css')
+          name:                         @language_json['name'],
+          comment_type:                 @language_json['comment_type'],
+          test_runner_url:              @language_json['url'],
+          output_content_type:          @language_json['output_content_type'],
+          prompt:                       (@language_json.dig('language', 'prompt') || 'ム') + ' ',
+          extension:                    @language_json.dig('language', 'extension'),
+          highlight_mode:               @language_json.dig('language', 'ace_mode'),
+          visible_success_output:       @language_json.dig('language', 'graphic').present?,
+          devicon:                      @language_json.dig('language', 'icon', 'name'),
+          triable:                      @language_json.dig('features', 'try').present?,
+          feedback:                     @language_json.dig('features', 'feedback').present?,
+          queriable:                    @language_json.dig('features', 'query').present?,
+          stateful_console:             @language_json.dig('features', 'stateful').present?,
+          multifile:                    @language_json.dig('features', 'multifile').present?,
+          test_extension:               @language_json.dig('test_framework', 'test_extension'),
+          test_template:                @language_json.dig('test_framework', 'template'),
+          layout_js_urls:               get_assets_for(:layout, 'js'),
+          layout_html_urls:             get_assets_for(:layout, 'html'),
+          layout_css_urls:              get_assets_for(:layout, 'css'),
+          editor_js_urls:               get_assets_for(:editor, 'js'),
+          editor_html_urls:             get_assets_for(:editor, 'html'),
+          editor_css_urls:              get_assets_for(:editor, 'css'),
+          layout_shows_loading_content: shows_loading_content_for?(:layout),
+          editor_shows_loading_content: shows_loading_content_for?(:editor)
         }
       end
 
@@ -115,7 +117,15 @@ module Mumukit
       end
 
       def get_assets_for(kind, content_type)
-        absolutize(@language_json.dig("#{kind}_assets_urls", content_type) || [])
+        absolutize(get_asset_field(kind, content_type) || [])
+      end
+
+      def shows_loading_content_for?(kind)
+        get_asset_field(kind, 'shows_loading_content').present?
+      end
+
+      def get_asset_field(kind, field)
+        @language_json.dig("#{kind}_assets_urls", field)
       end
 
       def absolutize(urls)

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -59,7 +59,9 @@ describe Mumukit::Bridge::Runner do
                                                       layout_css_urls: [],
                                                       editor_js_urls: [],
                                                       editor_html_urls: [],
-                                                      editor_css_urls: [] }
+                                                      editor_css_urls: [],
+                                                      layout_shows_loading_content: false,
+                                                      editor_shows_loading_content: false}
     end
 
     context 'when language is graphical' do
@@ -86,7 +88,8 @@ describe Mumukit::Bridge::Runner do
         'editor_assets_urls' => {
             'js' => ['javascripts/aa.js'],
             'html' => ['bb.html', 'cc.html'],
-            'css' => ['stylesheets/dd.css']
+            'css' => ['stylesheets/dd.css'],
+            'shows_loading_content' => true
         },
         'language' => {
             'name' => 'gobstones',
@@ -122,7 +125,9 @@ describe Mumukit::Bridge::Runner do
                                                     layout_css_urls: ["http://foo/stylesheets/d.css"],
                                                     editor_js_urls: ["http://foo/javascripts/aa.js"],
                                                     editor_html_urls: ["http://foo/bb.html", "http://foo/cc.html"],
-                                                    editor_css_urls: ["http://foo/stylesheets/dd.css"] }
+                                                    editor_css_urls: ["http://foo/stylesheets/dd.css"],
+                                                    layout_shows_loading_content: false,
+                                                    editor_shows_loading_content: true}
     end
 
     context 'when language has multifile feature' do
@@ -179,8 +184,9 @@ describe Mumukit::Bridge::Runner do
                                                   layout_css_urls: [],
                                                   editor_js_urls: [],
                                                   editor_html_urls: [],
-                                                  editor_css_urls: []
-      }
+                                                  editor_css_urls: [],
+                                                  layout_shows_loading_content: false,
+                                                  editor_shows_loading_content: false}
     end
   end
 


### PR DESCRIPTION
This generates two extra fields for a language: editor_shows_loading_content && layout_shows_loading_content which specify if that kind of assets should show a loading content while they are loading. 