### PR TITLE
Feature test summary

### DIFF
--- a/lib/mumukit/bridge/runner.rb
+++ b/lib/mumukit/bridge/runner.rb
@@ -18,7 +18,7 @@ module Mumukit
       #  {test: string, extra: string, content: string, expectations: [{binding:string, inspection: string})]}
       # Returns a hash
       #   {result: string,
-      #    test_results: [{title:string, status:symbol, result:string}],
+      #    test_results: [{title:string, status:symbol, result:string, summary:hash}],
       #    status: :passed|:failed|:errored|:aborted|:passed_with_warnings,
       #    expectation_results: [{binding:string, inspection:string, result:symbol}],
       #    feedback: string}

--- a/lib/mumukit/bridge/runner/response_type.rb
+++ b/lib/mumukit/bridge/runner/response_type.rb
@@ -40,7 +40,7 @@ module Mumukit::Bridge
 
       def parse_test_results(results)
         results.map do |it|
-          { summary: safe_compact(it['summary']).presence }
+          { summary: safe_compact(it['summary'])&.symbolize_keys.presence }
             .compact
             .merge(
               title: it['title'],

--- a/lib/mumukit/bridge/runner/response_type.rb
+++ b/lib/mumukit/bridge/runner/response_type.rb
@@ -39,10 +39,18 @@ module Mumukit::Bridge
       private
 
       def parse_test_results(results)
-        results.map { |it| {
-            title: it['title'],
-            status: it['status'].to_sym,
-            result: it['result']} }
+        results.map do |it|
+          { summary: safe_compact(it['summary']).presence }
+            .compact
+            .merge(
+              title: it['title'],
+              status: it['status'].to_sym,
+              result: it['result'])
+        end
+      end
+
+      def safe_compact(hash)
+        hash.try { |it| it.transform_values(&:presence).compact rescue nil }
       end
     end
 

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -66,7 +66,7 @@ describe Mumukit::Bridge::Runner do
       context 'when submission failed with summary' do
         let(:server_response) { {
             'testResults' => [
-                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {key: 'unexpected_result'}},
+                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {'key' => 'unexpected_result'}},
                 {'title' => 'false is false', 'status' => 'passed', 'result' => ''},
             ]
         } }
@@ -84,8 +84,8 @@ describe Mumukit::Bridge::Runner do
       context 'when submission failed with empty or illegal summary' do
         let(:server_response) { {
             'testResults' => [
-                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {key: nil}},
-                {'title' => 'nil is true', 'status' => 'failed', 'result' => 'nil != true', 'summary' => {key: ''}},
+                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {'key' => nil}},
+                {'title' => 'nil is true', 'status' => 'failed', 'result' => 'nil != true', 'summary' => {'key' => ''}},
                 {'title' => '1 is 1', 'status' => 'passed', 'result' => '', 'summary' => 'dfsdfsdf' },
                 {'title' => 'false is false', 'status' => 'passed', 'result' => '', 'summary' => {} }
             ]

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -66,13 +66,13 @@ describe Mumukit::Bridge::Runner do
       context 'when submission failed with summary' do
         let(:server_response) { {
             'testResults' => [
-                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {'key' => 'unexpected_result'}},
+                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {'type' => 'unexpected_result'}},
                 {'title' => 'false is false', 'status' => 'passed', 'result' => ''},
             ]
         } }
 
         it { expect(response[:status]).to eq(:failed) }
-        it { expect(response[:test_results]).to eq([{title: 'false is true', status: :failed, result: 'true != false', summary: {key: 'unexpected_result'}},
+        it { expect(response[:test_results]).to eq([{title: 'false is true', status: :failed, result: 'true != false', summary: {type: 'unexpected_result'}},
                                                     {title: 'false is false', status: :passed, result: ''}]) }
         it { expect(response[:response_type]).to eq(:structured) }
         it { expect(response[:expectation_results]).to be_empty }
@@ -84,8 +84,8 @@ describe Mumukit::Bridge::Runner do
       context 'when submission failed with empty or illegal summary' do
         let(:server_response) { {
             'testResults' => [
-                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {'key' => nil}},
-                {'title' => 'nil is true', 'status' => 'failed', 'result' => 'nil != true', 'summary' => {'key' => ''}},
+                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {'type' => nil}},
+                {'title' => 'nil is true', 'status' => 'failed', 'result' => 'nil != true', 'summary' => {'type' => ''}},
                 {'title' => '1 is 1', 'status' => 'passed', 'result' => '', 'summary' => 'dfsdfsdf' },
                 {'title' => 'false is false', 'status' => 'passed', 'result' => '', 'summary' => {} }
             ]

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -66,14 +66,18 @@ describe Mumukit::Bridge::Runner do
       context 'when submission failed with summary' do
         let(:server_response) { {
             'testResults' => [
-                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {'type' => 'unexpected_result'}},
-                {'title' => 'false is false', 'status' => 'passed', 'result' => ''},
+                {'title' => 'f(1)', 'status' => 'failed', 'result' => '<error>', 'summary' => {'type' => 'unexpected_result'}},
+                {'title' => 'f(2)', 'status' => 'failed', 'result' => '<error>', 'summary' => {'message' => 'check your tests'}},
+                {'title' => 'f(3)', 'status' => 'failed', 'result' => '<error>', 'summary' => {'type' => 'undefined_reference', 'message' => 'There are undefined references'}},
+                {'title' => 'f(4)', 'status' => 'passed', 'result' => ''},
             ]
         } }
 
         it { expect(response[:status]).to eq(:failed) }
-        it { expect(response[:test_results]).to eq([{title: 'false is true', status: :failed, result: 'true != false', summary: {type: 'unexpected_result'}},
-                                                    {title: 'false is false', status: :passed, result: ''}]) }
+        it { expect(response[:test_results]).to eq([{title: 'f(1)', status: :failed, result: '<error>', summary: {type: 'unexpected_result'}},
+                                                    {title: 'f(2)', status: :failed, result: '<error>', summary: {message: 'check your tests'}},
+                                                    {title: 'f(3)', status: :failed, result: '<error>', summary: {type: 'undefined_reference', message: 'There are undefined references'}},
+                                                    {title: 'f(4)', status: :passed, result: ''}]) }
         it { expect(response[:response_type]).to eq(:structured) }
         it { expect(response[:expectation_results]).to be_empty }
         it { expect(response[:feedback]).to eq('') }

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -63,6 +63,23 @@ describe Mumukit::Bridge::Runner do
         it { expect(response[:feedback]).to eq('') }
       end
 
+      context 'when submission failed with summary' do
+        let(:server_response) { {
+            'testResults' => [
+                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {key: 'unexpected_result'}},
+                {'title' => 'false is false', 'status' => 'passed', 'result' => ''},
+            ]
+        } }
+
+        it { expect(response[:status]).to eq(:failed) }
+        it { expect(response[:test_results]).to eq([{title: 'false is true', status: :failed, result: 'true != false', summary: {key: 'unexpected_result'}},
+                                                    {title: 'false is false', status: :passed, result: ''}]) }
+        it { expect(response[:response_type]).to eq(:structured) }
+        it { expect(response[:expectation_results]).to be_empty }
+        it { expect(response[:feedback]).to eq('') }
+      end
+
+
       context 'when submission passed with warnings' do
         let(:server_response) { {
             'testResults' => [

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -79,6 +79,28 @@ describe Mumukit::Bridge::Runner do
         it { expect(response[:feedback]).to eq('') }
       end
 
+      # this should not happen when runner is implemented using mumukit, since mumukit already removes empty summaries
+      # and does not produce illegal summaries
+      context 'when submission failed with empty or illegal summary' do
+        let(:server_response) { {
+            'testResults' => [
+                {'title' => 'false is true', 'status' => 'failed', 'result' => 'true != false', 'summary' => {key: nil}},
+                {'title' => 'nil is true', 'status' => 'failed', 'result' => 'nil != true', 'summary' => {key: ''}},
+                {'title' => '1 is 1', 'status' => 'passed', 'result' => '', 'summary' => 'dfsdfsdf' },
+                {'title' => 'false is false', 'status' => 'passed', 'result' => '', 'summary' => {} }
+            ]
+        } }
+
+        it { expect(response[:status]).to eq(:failed) }
+        it { expect(response[:test_results]).to eq([{title: 'false is true', status: :failed, result: 'true != false'},
+                                                    {title: 'nil is true', status: :failed, result: 'nil != true'},
+                                                    {title: '1 is 1', status: :passed, result: ''},
+                                                    {title: 'false is false', status: :passed, result: ''}]) }
+        it { expect(response[:response_type]).to eq(:structured) }
+        it { expect(response[:expectation_results]).to be_empty }
+        it { expect(response[:feedback]).to eq('') }
+      end
+
 
       context 'when submission passed with warnings' do
         let(:server_response) { {


### PR DESCRIPTION
Bridge support for https://github.com/mumuki/mumukit/pull/104

Handling new summary field in a backward compatible manner. Dealing defensively with weird scenarios that should never happen in order to minimize risks. 

Ignoring: 

* missing summaries
* empty summaries
* summaries with blank values
* non-hash summaries



